### PR TITLE
Fix: geler toutes les entites pendant pause, level-up et game over (#1)

### DIFF
--- a/src/scripts/DayNightCycle.ts
+++ b/src/scripts/DayNightCycle.ts
@@ -1,5 +1,5 @@
 import * as pc from 'playcanvas';
-import { DAY_CYCLE_DURATION } from '../constants';
+import { DAY_CYCLE_DURATION, GameState } from '../constants';
 
 export class DayNightCycle extends pc.Script {
     static scriptName = 'dayNightCycle';
@@ -14,7 +14,7 @@ export class DayNightCycle extends pc.Script {
 
     update(dt: number): void {
         const game = (this.app as any).__game;
-        if (!game || game.state !== 'playing') return;
+        if (!game || game.state !== GameState.PLAYING) return;
 
         this.timeOfDay = (this.timeOfDay + dt / this.cycleDuration) % 1.0;
 

--- a/src/scripts/EnemyAI.ts
+++ b/src/scripts/EnemyAI.ts
@@ -1,5 +1,5 @@
 import * as pc from 'playcanvas';
-import { ENEMY_CONTACT_COOLDOWN } from '../constants';
+import { ENEMY_CONTACT_COOLDOWN, GameState } from '../constants';
 
 export class EnemyAI extends pc.Script {
     static scriptName = 'enemyAI';
@@ -10,6 +10,9 @@ export class EnemyAI extends pc.Script {
     private dir: pc.Vec3 = new pc.Vec3();
 
     update(dt: number): void {
+        const game = (this.app as any).__game;
+        if (game && game.state !== GameState.PLAYING) return;
+
         const player = this.app.root.findByName('player');
         if (!player) return;
 

--- a/src/scripts/Health.ts
+++ b/src/scripts/Health.ts
@@ -1,4 +1,5 @@
 import * as pc from 'playcanvas';
+import { GameState } from '../constants';
 
 export class Health extends pc.Script {
     static scriptName = 'health';
@@ -13,6 +14,9 @@ export class Health extends pc.Script {
     }
 
     update(dt: number): void {
+        const game = (this.app as any).__game;
+        if (game && game.state !== GameState.PLAYING) return;
+
         if (this.invulnTimer > 0) {
             this.invulnTimer -= dt;
         }

--- a/src/scripts/PlayerController.ts
+++ b/src/scripts/PlayerController.ts
@@ -1,5 +1,5 @@
 import * as pc from 'playcanvas';
-import { PLAYER_BASE_SPEED, ARENA_HALF } from '../constants';
+import { PLAYER_BASE_SPEED, ARENA_HALF, GameState } from '../constants';
 
 export class PlayerController extends pc.Script {
     static scriptName = 'playerController';
@@ -10,7 +10,7 @@ export class PlayerController extends pc.Script {
 
     update(dt: number): void {
         const game = (this.app as any).__game;
-        if (!game) return;
+        if (!game || game.state !== GameState.PLAYING) return;
 
         const input = game.inputManager.getState();
 

--- a/src/scripts/Projectile.ts
+++ b/src/scripts/Projectile.ts
@@ -1,4 +1,5 @@
 import * as pc from 'playcanvas';
+import { GameState } from '../constants';
 
 export class Projectile extends pc.Script {
     static scriptName = 'projectile';
@@ -11,6 +12,9 @@ export class Projectile extends pc.Script {
     private age: number = 0;
 
     update(dt: number): void {
+        const game = (this.app as any).__game;
+        if (game && game.state !== GameState.PLAYING) return;
+
         this.age += dt;
 
         if (this.age >= this.lifetime) {

--- a/src/scripts/XPPickup.ts
+++ b/src/scripts/XPPickup.ts
@@ -1,5 +1,5 @@
 import * as pc from 'playcanvas';
-import { XP_PICKUP_MAGNET_SPEED } from '../constants';
+import { XP_PICKUP_MAGNET_SPEED, GameState } from '../constants';
 
 export class XPPickup extends pc.Script {
     static scriptName = 'xpPickup';
@@ -13,6 +13,9 @@ export class XPPickup extends pc.Script {
     }
 
     update(dt: number): void {
+        const game = (this.app as any).__game;
+        if (game && game.state !== GameState.PLAYING) return;
+
         const player = this.app.root.findByName('player');
         if (!player) return;
 
@@ -23,7 +26,6 @@ export class XPPickup extends pc.Script {
         const dist = Math.sqrt(dx * dx + dz * dz);
 
         // Get magnet radius from game
-        const game = (this.app as any).__game;
         const magnetRadius = game?.playerStats?.magnetRadius ?? 3;
 
         if (dist < magnetRadius) {


### PR DESCRIPTION
Chaque script PlayCanvas verifie maintenant game.state === PLAYING avant d'executer sa logique update(). Les ennemis, projectiles, pickups XP et le joueur se figent correctement dans tous les menus.